### PR TITLE
Update GitHub stats links to use fast service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # execute233
 
-[![最常用的语言](https://github-readme-stats.vercel.app/api/top-langs?username=execute233&theme=algolia&locale=cn "最常用的语言")](https://github-readme-stats.vercel.app/api/top-langs?username=execute233&theme=algolia&locale=cn)
+[![最常用的语言](https://github-readme-stats-fast.vercel.app/api/top-langs?username=execute233&theme=algolia&locale=cn "最常用的语言")](https://github-readme-stats.vercel.app/api/top-langs?username=execute233&theme=algolia&locale=cn)
 
-<!--[![GitHub 统计](https://github-readme-stats.vercel.app/api?username=execute233&count_private=true&theme=algolia&locale=cn&include_all_commits=true&show_icons=true "GitHub 统计")](https://github-readme-stats.vercel.app/api?username=execute233&count_private=true&theme=algolia&locale=cn&include_all_commits=true&show_icons=true)-->
+<!--[![GitHub 统计](https://github-readme-stats-fast.vercel.app/api?username=execute233&count_private=true&theme=algolia&locale=cn&include_all_commits=true&show_icons=true "GitHub 统计")](https://github-readme-stats.vercel.app/api?username=execute233&count_private=true&theme=algolia&locale=cn&include_all_commits=true&show_icons=true)-->
 
 
 ### **学生**


### PR DESCRIPTION
We don't know how `fast` this service is, but the original service has stopped working.